### PR TITLE
missing keyword fixed for installing nginx on flask-on-aws-ec2.md

### DIFF
--- a/flask-on-aws-ec2.md
+++ b/flask-on-aws-ec2.md
@@ -100,7 +100,7 @@ Finally, we set up Nginx as a reverse-proxy to accept the requests from the user
 
 Install Nginx 
 ```bash
-sudo apt-get nginx
+sudo apt-get install nginx
 ```
 Start the Nginx service and go to the Public IP address of your EC2 on the browser to see the default nginx landing page
 ```bash


### PR DESCRIPTION
updated the `nginx` installation command in the documentation to `sudo apt-get install nginx`